### PR TITLE
fix: Display the correct user's AFK status on mention

### DIFF
--- a/events/handler.js
+++ b/events/handler.js
@@ -231,15 +231,15 @@ module.exports = (bot) => {
             if (m.key.fromMe) return;
 
             // Penanganan AFK (Pengguna yang disebutkan atau di-balas/quote)
-            const userMentions = ctx.quoted.senderJid ? [tools.general.getID(ctx.quoted.senderJid)] : m.message?.extendedTextMessage?.contextInfo?.mentionedJid?.map(jid => tools.general.getID(jid)) || [];
+            const userMentions = ctx.quoted.senderJid ? [tools.general.getID(ctx.quoted.senderJid)] : m.message?.[m.messageType]?.contextInfo?.mentionedJid?.map(jid => tools.general.getID(jid)) || [];
             if (userMentions.length > 0) {
                 if (m.key.fromMe) return;
 
                 for (const userMention of userMentions) {
                     const userMentionAfk = await db.get(`user.${userMention}.afk`) || {};
-                    if (userMentionAfk.reason && userMentionAfk.timestamp) {
-                        const timeago = tools.general.convertMsToDuration(Date.now() - userAfk.timestamp);
-                        await ctx.reply(quote(`📴 Jangan tag! Dia sedang AFK ${userAfk.reason ? `dengan alasan "${userAfk.reason}"` : "tanpa alasan"} selama ${timeago}.`));
+                    if (userMentionAfk.reason || userMentionAfk.timestamp) {
+                        const timeago = tools.general.convertMsToDuration(Date.now() - userMentionAfk.timestamp);
+                        await ctx.reply(quote(`📴 Jangan tag! Dia sedang AFK ${userMentionAfk.reason ? `dengan alasan "${userMentionAfk.reason}"` : "tanpa alasan"} selama ${timeago}.`));
                     }
                 }
             }


### PR DESCRIPTION
There was a critical logic bug in the AFK feature. When a user was mentioned, the system would incorrectly fetch the AFK status of the message sender (`userAfk`) instead of the mentioned user (`userMentionAfk`). This resulted in the bot displaying the wrong AFK status or none at all.

This commit corrects the issue by ensuring the proper variable (`userMentionAfk`) is used to fetch and display the AFK details for the user who was actually tagged.

Additionally, as a secondary improvement, mention detection has been made more robust to work across all message types (including image/video captions) by using the dynamic `[m.messageType]` property.