### PR TITLE
 fix: prevent viewOnce message causing crash

### DIFF
--- a/commands/downloader/facebookdl.js
+++ b/commands/downloader/facebookdl.js
@@ -15,13 +15,13 @@ module.exports = {
         if (!ctx.helper.isUrl(url)) return await ctx.reply(ctx.format.info(config.msg.invalidUrl));
 
         try {
-            const apiUrl = ctx.api.createUrl("nexray", "/downloader/facebook", {
+            const apiUrl = ctx.api.createUrl("mikako", "/api/fb", {
                 url
             });
-            const result = (await ctx.request.get(apiUrl)).data.result;
+            const result = (await ctx.request.get(apiUrl)).data.data;
             await ctx.reply({
                 video: {
-                    url: result.video_hd || result.video_sd
+                    url: result.videoUrl[0].url
                 },
                 caption: `❖ ${ctx.format.bold("URL")}: ${url}`
             });

--- a/events/call.js
+++ b/events/call.js
@@ -1,4 +1,4 @@
-const Baileys = require("baileys");
+const Baileys = require("@itsliaaa/baileys");
 const util = require("node:util");
 
 module.exports = (bot) => {

--- a/lib/api.js
+++ b/lib/api.js
@@ -10,6 +10,9 @@ const APIs = {
     },
     siputzx: {
         baseURL: "https://api.siputzx.my.id"
+    },
+    mikako: {
+        baseURL: "https://api.mikako.store"
     }
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -146,7 +146,6 @@ class Client {
             if (event.type !== "notify") return;
 
             for (const message of event.messages) {
-                if (!message) return
                 if (this._shouldIgnore(message)) continue;
 
                 const sender = this._getSender(message.key);

--- a/lib/client.js
+++ b/lib/client.js
@@ -146,6 +146,7 @@ class Client {
             if (event.type !== "notify") return;
 
             for (const message of event.messages) {
+                if(!message) return;
                 if (this._shouldIgnore(message)) continue;
 
                 const sender = this._getSender(message.key);

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,4 +1,4 @@
-const Baileys = require("baileys");
+const Baileys = require("@itsliaaa/baileys");
 const EventEmitter = require("node:events");
 const fs = require("node:fs");
 const path = require("node:path");

--- a/lib/client.js
+++ b/lib/client.js
@@ -146,6 +146,7 @@ class Client {
             if (event.type !== "notify") return;
 
             for (const message of event.messages) {
+                if (!message) return
                 if (this._shouldIgnore(message)) continue;
 
                 const sender = this._getSender(message.key);

--- a/lib/ctx.js
+++ b/lib/ctx.js
@@ -1,4 +1,4 @@
-const Baileys = require("baileys");
+const Baileys = require("@itsliaaa/baileys");
 const util = require("node:util");
 const { uguu } = require("@neoxr/helper");
 const axios = require("axios");

--- a/lib/group.js
+++ b/lib/group.js
@@ -1,4 +1,4 @@
-const Baileys = require("baileys");
+const Baileys = require("@itsliaaa/baileys");
 
 class Group {
     constructor(ctx) {

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,5 +1,5 @@
 const util = require("node:util");
-const Baileys = require("baileys");
+const Baileys = require("@itsliaaa/baileys");
 const { globSync } = require("glob");
 const api = require("./api");
 const Ctx = require("./ctx");

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -61,12 +61,9 @@ function getBaileysVersion() {
 
 function getBodyFromMsg(msg) {
     let message = Baileys.extractMessageContent(msg.message);
-    if (message?.conversation) return message.conversation;
-    const messageContentType = Baileys.getContentType(message)
-    console.log(messageContentType)
-    if(!messageContentType) return ""
-    message = message[messageContentType];
-    if (message?.nativeFlowResponseMessage) {
+    if (message.conversation) return message.conversation;
+    message = message[Baileys.getContentType(message)];
+    if (message.nativeFlowResponseMessage) {
         try {
             const params = JSON.parse(message.nativeFlowResponseMessage.paramsJson || '{}');
             return params?.id || params?.display_text || "";

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,4 +1,4 @@
-const Baileys = require("baileys");
+const Baileys = require("@itsliaaa/baileys");
 const didYouMean = require("didyoumean");
 const crypto = require("node:crypto");
 const util = require("node:util");

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -61,9 +61,11 @@ function getBaileysVersion() {
 
 function getBodyFromMsg(msg) {
     let message = Baileys.extractMessageContent(msg.message);
-    if (message.conversation) return message.conversation;
-    message = message[Baileys.getContentType(message)];
-    if (message.nativeFlowResponseMessage) {
+    if (message?.conversation) return message.conversation;
+    const messageContentType = Baileys.getContentType(message);
+    if(!messageContentType) return "";
+    message = message[messageContentType];
+    if (message?.nativeFlowResponseMessage) {
         try {
             const params = JSON.parse(message.nativeFlowResponseMessage.paramsJson || '{}');
             return params?.id || params?.display_text || "";

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -61,9 +61,12 @@ function getBaileysVersion() {
 
 function getBodyFromMsg(msg) {
     let message = Baileys.extractMessageContent(msg.message);
-    if (message.conversation) return message.conversation;
-    message = message[Baileys.getContentType(message)];
-    if (message.nativeFlowResponseMessage) {
+    if (message?.conversation) return message.conversation;
+    const messageContentType = Baileys.getContentType(message)
+    console.log(messageContentType)
+    if(!messageContentType) return ""
+    message = message[messageContentType];
+    if (message?.nativeFlowResponseMessage) {
         try {
             const params = JSON.parse(message.nativeFlowResponseMessage.paramsJson || '{}');
             return params?.id || params?.display_text || "";

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@neoxr/helper": "^2.3.15",
     "axios": "^1.19.0",
     "axios-retry": "^4.5.0",
-    "baileys": "github:itsliaaa/baileys",
+    "@itsliaaa/baileys": "0.3.18-final",
     "cfonts": "^3.3.1",
     "didyoumean": "^1.2.2",
     "glob": "^13.0.6",


### PR DESCRIPTION
bot langsung crash ketika pesan sekali lihat diterima, karena hasil ekstraksi pesan bernilai _undefined_ ketika di proses `Baileys.getContentType()`.